### PR TITLE
Fixed occasional NPE on selection change.

### DIFF
--- a/plugins/com.cisco.yangide.editor/src/com/cisco/yangide/editor/editors/YangEditor.java
+++ b/plugins/com.cisco.yangide.editor/src/com/cisco/yangide/editor/editors/YangEditor.java
@@ -150,7 +150,9 @@ public class YangEditor extends TextEditor implements IProjectionListener, IYang
             if (event.getSelection() instanceof ITextSelection) {
                 ITextSelection textSelection = (ITextSelection) event.getSelection();
                 try {
-                    if (null != outlinePage) {
+                    // Checking for getModule() != null is to deal with the unusual case of removing the "module"
+                    // statement (or emptying the entire buffer) after setting a selection.
+                    if ((null != outlinePage) && (null != getModule())) {
                         outlinePage.selectNode(getModule().getNodeAtPosition(textSelection.getOffset()));
                     }
                 } catch (YangModelException e) {


### PR DESCRIPTION
This deals with the unusual case of selecting something in the buffer
and then emptying the buffer.  The selection change listener fires
around that point, but "getModule()" returns null (in some cases,
apparently), causing the NPE when that happens.